### PR TITLE
Add data exploration utils phonems

### DIFF
--- a/app/utils/data-exploration.py
+++ b/app/utils/data-exploration.py
@@ -2,6 +2,7 @@ import os
 import soundfile as sf
 import pandas as pd
 import json
+import eng_to_ipa as ipa
 
 def get_data_from_directory(directory_path):
     """
@@ -85,3 +86,9 @@ def add_phonems_and_tokens_to_df(df, tokenized_transcript, mapping_file):
     df['phonems'] = df['sequence_id'].map(phonems_dict)
 
     return df
+
+def text_to_phonems_with_eng_to_ipa(sentence):        
+    ipa_text = ipa.convert(sentence, keep_punct=False, stress_marks=None)
+    phonemes = list(ipa_text.replace(" ", "")) 
+
+    return phonemes

--- a/app/utils/data-exploration.py
+++ b/app/utils/data-exploration.py
@@ -48,3 +48,5 @@ def get_data_from_directory(directory_path):
                 data['duration'].append(get_audio_duration(audio_path))
 
     return pd.DataFrame(data)
+
+

--- a/app/utils/data-exploration.py
+++ b/app/utils/data-exploration.py
@@ -1,0 +1,50 @@
+import os
+import soundfile as sf
+import pandas as pd
+
+def get_data_from_directory(directory_path):
+    """
+    Parcourt des dossiers imbriqués contenant des fichiers audio (en .flac) et des transcriptions (en .txt).
+    pour en extraire un sequence_id, une transcription, une durée et le path du fichier audio pour chaque extrait audio.
+    
+    Parameters:
+    - dataset_path: path vers le répertoire contenant les fichiers audio et texte.
+
+    Return:
+    - Dataframe qui contient les colonnes 'sequence_id', 'transcription', 'duration', et 'audio_file'.
+    """
+    
+    def get_transcriptions_from_file(file_path):
+        with open(file_path, 'r') as file:
+            lines = file.readlines()
+            return {line.split()[0]: " ".join(line.split()[1:]) for line in lines}
+    
+    def get_audio_duration(file_path):
+        with sf.SoundFile(file_path) as f:
+            return len(f) / f.samplerate
+    
+    data = {
+        'sequence_id': [],
+        'transcription': [],
+        'duration': [],
+        'audio_file': []
+    }
+    
+    for root, _, files in os.walk(directory_path):
+        transcription_files = [file for file in files if file.endswith(".txt")]
+        
+        transcripts = {}
+        if transcription_files:
+            transcripts = get_transcriptions_from_file(os.path.join(root, transcription_files[0]))
+
+        for filename in files:
+            if filename.endswith(".flac"):
+                sequence_id = filename.strip('.flac')
+                audio_path = os.path.join(root, filename)
+                
+                data['sequence_id'].append(sequence_id)
+                data['audio_file'].append(audio_path)
+                data['transcription'].append(transcripts.get(sequence_id, ""))
+                data['duration'].append(get_audio_duration(audio_path))
+
+    return pd.DataFrame(data)

--- a/app/utils/data-exploration.py
+++ b/app/utils/data-exploration.py
@@ -1,6 +1,7 @@
 import os
 import soundfile as sf
 import pandas as pd
+import json
 
 def get_data_from_directory(directory_path):
     """
@@ -49,4 +50,38 @@ def get_data_from_directory(directory_path):
 
     return pd.DataFrame(data)
 
+def add_phonems_and_tokens_to_df(df, tokenized_transcript, mapping_file):
+    """
+    Ajoute les colonnes 'phonem_tokens' et 'phonems' au DataFrame en utilisant un fichier qui contient les séquences de 
+    phonems de tokens associées à chaque transcription et un fichier de mapping de phonèmes (phoneme <=> int)
+    
+    Parameters:
+    - DataFrame initial (colonne nécessaire : sequence_id)
+    - tokenized_transcript : chemin vers le fichier contenant une séquence de phonem tokens pour chaque sequence_id.
+    - mapping_file : chemin vers le fichier JSON contenant le mapping des phonèmes en tokens.
+    
+    Returns:
+    - DataFrame initial avec les colonnes 'phonem_tokens' et 'phonems'.
+    """
+    
+    with open(mapping_file, 'r') as file:
+        phoneme_mapping = json.load(file)
+    inverted_mapping = {int(value): key for key, value in phoneme_mapping.items()}
+    
+    phonem_tokens_dict = {}
+    phonems_dict = {}
 
+    with open(tokenized_transcript, 'r') as file:
+        for line in file:
+            tokens = line.strip().split()
+            sequence_id = tokens[0]
+            token_phonem_sequence = [int(token) for token in tokens[1:]]
+            phonems = [inverted_mapping[token] for token in token_phonem_sequence]
+            
+            phonem_tokens_dict[sequence_id] = token_phonem_sequence
+            phonems_dict[sequence_id] = phonems
+
+    df['phonem_tokens'] = df['sequence_id'].map(phonem_tokens_dict)
+    df['phonems'] = df['sequence_id'].map(phonems_dict)
+
+    return df

--- a/parameters.py
+++ b/parameters.py
@@ -1,0 +1,6 @@
+# PATHS 
+path_audio_and_transcript_1h = 'raw_data/librispeech_finetuning/1h'
+path_audio_and_transcript_9h = 'raw_data/librispeech_finetuning/9h'
+path_audio_and_transcript_100h = 'raw_data/librispeech_finetuning/100h'
+path_phonemes = 'raw_data/librispeech_finetuning/phones'
+mapping_file_path = f"{path_phonemes}/phones_mapping.json"


### PR DESCRIPTION
 **add `add_phonems_and_tokens_to_df `method in data_exploration utils :** 

    Ajoute les colonnes 'phonem_tokens' et 'phonems' au DataFrame en utilisant un fichier qui contient les séquences de 
    phonems de tokens associées à chaque transcription et un fichier de mapping de phonèmes (phoneme <=> int)
    
    Parameters:
    - DataFrame initial (colonne nécessaire : sequence_id)
    - tokenized_transcript : chemin vers le fichier contenant une séquence de phonem tokens pour chaque sequence_id.
    - mapping_file : chemin vers le fichier JSON contenant le mapping des phonèmes en tokens.
    
    Returns:
    - DataFrame initial avec les colonnes 'phonem_tokens' et 'phonems'.
